### PR TITLE
fix: ignore comments with only a `-` or `+`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Examples:
 Score comments have the (regex) grammar
 
 ```typescript
-/([+|-]\d*)(:.*)?/
+/([+|-]\d+)(:.*)?/
 ```
 
 where only the first capturing group is used in accumultating the total score.
@@ -66,6 +66,7 @@ Not score comments:
 
 - `observation...` (+0 to score)
 - `3` (+0 to score)
+- `-` (+0 to score)
 
 #### Partial grading
 

--- a/src/grader.ts
+++ b/src/grader.ts
@@ -104,7 +104,7 @@ async function hasScoreComment(metadata: api.RequestMetadata):
 
 /**
  * Reads comments of form
- *   ([+|-]\d*)(:.*)?
+ *   ([+|-]\d+)(:.*)?
  *   ^^^^^^^^^^------- $SCORE
  *             ^^^^^-- $COMMENT
  * on the commit and accumulates discovered $SCORES on MAX_SCORE.
@@ -114,7 +114,7 @@ async function hasScoreComment(metadata: api.RequestMetadata):
  * @return promise containing total calculated score
  */
 async function scoreComments(metadata: api.RequestMetadata): Promise<number> {
-  const SCORE_COMMENT_GRAMMAR = /([+|-]\d*)(:.*)?/;
+  const SCORE_COMMENT_GRAMMAR = /([+|-]\d+)(:.*)?/;
   const comments: api.CommitCommentsResponse[] =
       await rp.get(makeRequest(metadata)).catch(Grader.onError);
 


### PR DESCRIPTION
Previously, the score comments grammar picked up scores with no numbers
if they included a `-` or `+`. This fixes that.